### PR TITLE
feat(neutral): add neutral button

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,8 @@ screenshots
 .releaserc
 package-lock.json
 yarn.lock
+metro.config.js
+babel.config.js
 
 # Xcode
 #

--- a/README.md
+++ b/README.md
@@ -88,12 +88,15 @@ setDate = (event, date) => {};
 ```
 Events returned by onChange function:
 ```js
-import { ACTION_DATE_SET, ACTION_DISMISSED } from 'react-native-month-year-picker';
+import { ACTION_DATE_SET, ACTION_DISMISSED, ACTION_NEUTRAL } from 'react-native-month-year-picker';
 ...
 onValueChange = (event, newDate) => {
   switch(event) {
     case ACTION_DATE_SET:
       onSuccess(newDate);
+      break;
+    case ACTION_NEUTRAL:
+      onNeutral(newDate);
       break;
     case ACTION_DISMISSED:
     default:
@@ -149,6 +152,14 @@ Picker modal cancelation button text. Default `Cancel`.
 
 ```js
 <RNMonthPicker cancelButton="Abort" />
+```
+
+#### `neutralButton` (`optional`)
+
+Picker modal neutral button text. If not sent, button won't appear. Default `null`.
+
+```js
+<RNMonthPicker neutralButton="Delete" />
 ```
 
 ## Running example

--- a/android/src/main/java/com/gusparis/monthpicker/adapter/PickerDialogListener.java
+++ b/android/src/main/java/com/gusparis/monthpicker/adapter/PickerDialogListener.java
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.WritableNativeMap;
 
 import static com.gusparis.monthpicker.adapter.RNActions.ACTION_DATE_SET;
 import static com.gusparis.monthpicker.adapter.RNActions.ACTION_DISMISSED;
+import static com.gusparis.monthpicker.adapter.RNActions.ACTION_NEUTRAL;
 
 class PickerDialogListener implements OnDateSetListener, OnDismissListener, OnClickListener {
 
@@ -26,10 +27,11 @@ class PickerDialogListener implements OnDateSetListener, OnDismissListener, OnCl
   }
 
   @Override
-  public void onDateSet(DatePicker view, int year, int month, int day) {
+  public void onDateSet(DatePicker view, int year, int month, int flag) {
     if (!promiseResolved && reactContext.hasActiveCatalystInstance()) {
       WritableMap result = new WritableNativeMap();
-      result.putString("action", ACTION_DATE_SET.value());
+      final RNActions action = flag == 0 ? ACTION_DATE_SET : ACTION_NEUTRAL;
+      result.putString("action", action.value());
       result.putInt("year", year);
       result.putInt("month", month + 1);
       promise.resolve(result);

--- a/android/src/main/java/com/gusparis/monthpicker/adapter/PickerDialogListener.java
+++ b/android/src/main/java/com/gusparis/monthpicker/adapter/PickerDialogListener.java
@@ -3,7 +3,6 @@ package com.gusparis.monthpicker.adapter;
 import android.app.DatePickerDialog.OnDateSetListener;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnDismissListener;
-import android.content.DialogInterface.OnClickListener;
 import android.widget.DatePicker;
 
 import com.facebook.react.bridge.Promise;
@@ -15,7 +14,7 @@ import static com.gusparis.monthpicker.adapter.RNActions.ACTION_DATE_SET;
 import static com.gusparis.monthpicker.adapter.RNActions.ACTION_DISMISSED;
 import static com.gusparis.monthpicker.adapter.RNActions.ACTION_NEUTRAL;
 
-class PickerDialogListener implements OnDateSetListener, OnDismissListener, OnClickListener {
+class PickerDialogListener implements OnDateSetListener, OnDismissListener {
 
   private final Promise promise;
   private boolean promiseResolved = false;
@@ -47,10 +46,5 @@ class PickerDialogListener implements OnDateSetListener, OnDismissListener, OnCl
       promise.resolve(result);
       promiseResolved = true;
     }
-  }
-
-  @Override
-  public void onClick(DialogInterface dialogInterface, int i) {
-
   }
 }

--- a/android/src/main/java/com/gusparis/monthpicker/adapter/PickerDialogListener.java
+++ b/android/src/main/java/com/gusparis/monthpicker/adapter/PickerDialogListener.java
@@ -3,6 +3,7 @@ package com.gusparis.monthpicker.adapter;
 import android.app.DatePickerDialog.OnDateSetListener;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnDismissListener;
+import android.content.DialogInterface.OnClickListener;
 import android.widget.DatePicker;
 
 import com.facebook.react.bridge.Promise;
@@ -13,7 +14,7 @@ import com.facebook.react.bridge.WritableNativeMap;
 import static com.gusparis.monthpicker.adapter.RNActions.ACTION_DATE_SET;
 import static com.gusparis.monthpicker.adapter.RNActions.ACTION_DISMISSED;
 
-class PickerDialogListener implements OnDateSetListener, OnDismissListener {
+class PickerDialogListener implements OnDateSetListener, OnDismissListener, OnClickListener {
 
   private final Promise promise;
   private boolean promiseResolved = false;
@@ -44,5 +45,10 @@ class PickerDialogListener implements OnDateSetListener, OnDismissListener {
       promise.resolve(result);
       promiseResolved = true;
     }
+  }
+
+  @Override
+  public void onClick(DialogInterface dialogInterface, int i) {
+
   }
 }

--- a/android/src/main/java/com/gusparis/monthpicker/adapter/RNActions.java
+++ b/android/src/main/java/com/gusparis/monthpicker/adapter/RNActions.java
@@ -3,7 +3,8 @@ package com.gusparis.monthpicker.adapter;
 public enum RNActions {
 
   ACTION_DATE_SET("dateSetAction"),
-  ACTION_DISMISSED("dismissedAction");
+  ACTION_DISMISSED("dismissedAction"),
+  ACTION_NEUTRAL("neutralAction");
 
   private String value;
 

--- a/android/src/main/java/com/gusparis/monthpicker/adapter/RNMonthPickerProps.java
+++ b/android/src/main/java/com/gusparis/monthpicker/adapter/RNMonthPickerProps.java
@@ -14,11 +14,13 @@ public interface RNMonthPickerProps {
 
   String cancelButton();
 
+  String neutralButton();
+
   Boolean enableAutoDarkMode();
 
   Locale locale();
 
-  void onChange(int year, int month);
+  void onChange(int year, int month, int flag);
 
   void onChange();
 }

--- a/android/src/main/java/com/gusparis/monthpicker/adapter/RNProps.java
+++ b/android/src/main/java/com/gusparis/monthpicker/adapter/RNProps.java
@@ -7,6 +7,7 @@ public enum RNProps {
   ENABLE_AUTO_DARK_MODE("enableAutoDarkMode"),
   OK_BUTTON("okButton"),
   CANCEL_BUTTON("cancelButton"),
+  NEUTRAL_BUTTON("neutralButton"),
   LOCALE("locale");
 
   private String value;

--- a/android/src/main/java/com/gusparis/monthpicker/adapter/RNPropsAdapter.java
+++ b/android/src/main/java/com/gusparis/monthpicker/adapter/RNPropsAdapter.java
@@ -12,6 +12,7 @@ import static com.gusparis.monthpicker.adapter.RNProps.CANCEL_BUTTON;
 import static com.gusparis.monthpicker.adapter.RNProps.ENABLE_AUTO_DARK_MODE;
 import static com.gusparis.monthpicker.adapter.RNProps.MAXIMUM_VALUE;
 import static com.gusparis.monthpicker.adapter.RNProps.MINIMUM_VALUE;
+import static com.gusparis.monthpicker.adapter.RNProps.NEUTRAL_BUTTON;
 import static com.gusparis.monthpicker.adapter.RNProps.OK_BUTTON;
 import static com.gusparis.monthpicker.adapter.RNProps.LOCALE;
 import static com.gusparis.monthpicker.adapter.RNProps.VALUE;
@@ -54,6 +55,11 @@ public class RNPropsAdapter implements RNMonthPickerProps {
   }
 
   @Override
+  public String neutralButton() {
+    return getStringValue(NEUTRAL_BUTTON, null);
+  }
+
+  @Override
   public Boolean enableAutoDarkMode() {
     return props.hasKey(ENABLE_AUTO_DARK_MODE.value()) ?
         props.getBoolean(ENABLE_AUTO_DARK_MODE.value()) :
@@ -70,8 +76,8 @@ public class RNPropsAdapter implements RNMonthPickerProps {
   }
 
   @Override
-  public void onChange(int year, int month) {
-    listener.onDateSet(null, year, month, 1);
+  public void onChange(int year, int month, int flag) {
+    listener.onDateSet(null, year, month, flag);
   }
 
   @Override

--- a/android/src/main/java/com/gusparis/monthpicker/builder/PickerViewFactory.java
+++ b/android/src/main/java/com/gusparis/monthpicker/builder/PickerViewFactory.java
@@ -65,6 +65,18 @@ public class PickerViewFactory {
             rnMonthPickerDialog.getDialog().cancel();
           }
         })
+        .setNeutralButton("Neutral", new DialogInterface.OnClickListener() {
+          @Override
+          public void onClick(DialogInterface dialogInterface, int i) {
+            rnMonthPickerDialog.getDialog().cancel();
+          }
+        })
+        .setNeutralButton("Neutral 2", new DialogInterface.OnClickListener() {
+          @Override
+          public void onClick(DialogInterface dialogInterface, int i) {
+            rnMonthPickerDialog.getDialog().cancel();
+          }
+        })
         .setNegativeButton(props.cancelButton(), new DialogInterface.OnClickListener() {
           @Override
           public void onClick(DialogInterface dialog, int id) {

--- a/android/src/main/java/com/gusparis/monthpicker/builder/PickerViewFactory.java
+++ b/android/src/main/java/com/gusparis/monthpicker/builder/PickerViewFactory.java
@@ -61,19 +61,7 @@ public class PickerViewFactory {
         .setPositiveButton(props.okButton(), new DialogInterface.OnClickListener() {
           @Override
           public void onClick(DialogInterface dialog, int id) {
-            props.onChange(yearPicker.getValue(), monthPicker.getValue());
-            rnMonthPickerDialog.getDialog().cancel();
-          }
-        })
-        .setNeutralButton("Neutral", new DialogInterface.OnClickListener() {
-          @Override
-          public void onClick(DialogInterface dialogInterface, int i) {
-            rnMonthPickerDialog.getDialog().cancel();
-          }
-        })
-        .setNeutralButton("Neutral 2", new DialogInterface.OnClickListener() {
-          @Override
-          public void onClick(DialogInterface dialogInterface, int i) {
+            props.onChange(yearPicker.getValue(), monthPicker.getValue(), 0);
             rnMonthPickerDialog.getDialog().cancel();
           }
         })
@@ -83,6 +71,17 @@ public class PickerViewFactory {
             rnMonthPickerDialog.getDialog().cancel();
           }
         });
+
+    if (props.neutralButton() != null) {
+      builder.setView(contentView)
+          .setNeutralButton(props.neutralButton(), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialogInterface, int i) {
+              props.onChange(yearPicker.getValue(), monthPicker.getValue(), 1);
+              rnMonthPickerDialog.getDialog().cancel();
+            }
+          });
+    }
 
     return builder.create();
   }

--- a/ios/RNMonthPicker+Toolbar.h
+++ b/ios/RNMonthPicker+Toolbar.h
@@ -11,6 +11,7 @@
 
 @property (nonatomic, copy) RCTBubblingEventBlock onCancel;
 @property (nonatomic, copy) RCTBubblingEventBlock onDone;
+@property (nonatomic, copy) RCTBubblingEventBlock onNeutral;
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
 
 @property (nonatomic, assign) NSDate* value;
@@ -18,6 +19,7 @@
 @property (nonatomic, assign) NSDate* maximumDate;
 @property (nonatomic, assign) NSString* okButtonLabel;
 @property (nonatomic, assign) NSString* cancelButtonLabel;
+@property (nonatomic, assign) NSString* neutralButtonLabel;
 
 - (void)initPicker:(NSString *)locale;
 

--- a/ios/RNMonthPicker+Toolbar.m
+++ b/ios/RNMonthPicker+Toolbar.m
@@ -19,9 +19,7 @@ RNMonthPicker *picker;
     if ((self = [super initWithFrame:frame])) {
         toolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(screen), 44)];
         cancelButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(onCancelButton)];
-        doneButton = [[UIBarButtonItem alloc] initWithTitle:@"Done" style:UIBarButtonItemStyleDone target:self action:@selector(onDoneButton)];
-        UIBarButtonItem *flexibleSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
-        [toolbar setItems:[NSArray arrayWithObjects:cancelButton, flexibleSpace,doneButton,nil]];
+        doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(onDoneButton)];
         picker = [RNMonthPicker new];
         picker.frame = CGRectMake(0, 44, CGRectGetWidth(screen), 200);
         UIColor* defaultColor;
@@ -37,12 +35,26 @@ RNMonthPicker *picker;
     return self;
 }
 
+- (void)didSetProps:(NSArray<NSString *> *)changedProps {
+    UIBarButtonItem *flexibleSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
+    if (_neutralButtonLabel) {
+        UIBarButtonItem *neutralButton = [[UIBarButtonItem alloc] initWithTitle:_neutralButtonLabel style:UIBarButtonItemStylePlain target:nil action:@selector(onNeutralButton)];
+        [toolbar setItems:[NSArray arrayWithObjects: cancelButton, neutralButton, flexibleSpace, doneButton, nil]];
+    } else {
+        [toolbar setItems:[NSArray arrayWithObjects: cancelButton, flexibleSpace, doneButton, nil]];
+    }
+}
+
 - (void)onCancelButton {
     _onCancel(@{});
 }
 
 - (void)onDoneButton {
     _onDone(@{});
+}
+
+- (void)onNeutralButton {
+    _onNeutral(@{});
 }
 
 - (void)setValue:(NSDate *)value {
@@ -66,19 +78,11 @@ RNMonthPicker *picker;
 }
 
 - (void)setOkButtonLabel:(NSString *)okButtonLabel {
-    NSString *label = okButtonLabel;
-    if (!okButtonLabel) {
-        label = @"Done";
-    }
-    [doneButton setTitle:label];
+    [doneButton setTitle:okButtonLabel];
 }
 
 - (void)setCancelButtonLabel:(NSString *)cancelButtonLabel {
-    NSString *label = cancelButtonLabel;
-    if (!cancelButtonLabel) {
-        label = @"Cancel";
-    }
-    [cancelButton setTitle:label];
+    [cancelButton setTitle:cancelButtonLabel];
 }
 
 @end

--- a/ios/RNMonthPickerManager.m
+++ b/ios/RNMonthPickerManager.m
@@ -19,12 +19,14 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(onCancel, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onDone, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onNeutral, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(value, NSDate)
 RCT_EXPORT_VIEW_PROPERTY(minimumDate, NSDate)
 RCT_EXPORT_VIEW_PROPERTY(maximumDate, NSDate)
 RCT_REMAP_VIEW_PROPERTY(okButton, okButtonLabel, NSString)
+RCT_REMAP_VIEW_PROPERTY(neutralButton, neutralButtonLabel, NSString)
 RCT_REMAP_VIEW_PROPERTY(cancelButton, cancelButtonLabel, NSString)
 
 RCT_CUSTOM_VIEW_PROPERTY(locale, NSString, RNMonthPickerToolbar) {

--- a/src/MonthPicker.android.js
+++ b/src/MonthPicker.android.js
@@ -2,7 +2,12 @@ import moment from 'moment';
 import invariant from 'invariant';
 
 import RNMonthPickerDialogModule from './RNMonthPickerDialogModule';
-import { ACTION_DATE_SET, ACTION_DISMISSED, NATIVE_FORMAT } from './constants';
+import {
+  ACTION_DATE_SET,
+  ACTION_DISMISSED,
+  ACTION_NEUTRAL,
+  NATIVE_FORMAT,
+} from './constants';
 
 const MonthPicker = ({
   value,
@@ -23,6 +28,7 @@ const MonthPicker = ({
       let date;
       switch (action) {
         case ACTION_DATE_SET:
+        case ACTION_NEUTRAL:
           date = moment(`${month}-${year}`, NATIVE_FORMAT).toDate();
           break;
         case ACTION_DISMISSED:

--- a/src/MonthPicker.ios.js
+++ b/src/MonthPicker.ios.js
@@ -4,7 +4,12 @@ import moment from 'moment';
 import invariant from 'invariant';
 
 import RNMonthPickerView from './RNMonthPickerNativeComponent';
-import { ACTION_DATE_SET, ACTION_DISMISSED, NATIVE_FORMAT } from './constants';
+import {
+  ACTION_DATE_SET,
+  ACTION_DISMISSED,
+  ACTION_NEUTRAL,
+  NATIVE_FORMAT,
+} from './constants';
 
 const { width } = Dimensions.get('screen');
 const { Value, timing } = Animated;
@@ -27,9 +32,11 @@ const MonthPicker = ({
   value,
   minimumDate,
   maximumDate,
-  onChange: onConfirm,
+  onChange: onAction,
   locale = '',
-  ...restProps
+  okButton,
+  cancelButton,
+  neutralButton,
 }) => {
   invariant(value, 'value prop is required!');
 
@@ -65,7 +72,7 @@ const MonthPicker = ({
   const onDone = useCallback(() => {
     slideOut(
       ({ finished }) =>
-        finished && onConfirm && onConfirm(ACTION_DATE_SET, selectedDate),
+        finished && onAction && onAction(ACTION_DATE_SET, selectedDate),
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedDate]);
@@ -73,10 +80,18 @@ const MonthPicker = ({
   const onCancel = useCallback(() => {
     slideOut(
       ({ finished }) =>
-        finished && onConfirm && onConfirm(ACTION_DISMISSED, undefined),
+        finished && onAction && onAction(ACTION_DISMISSED, undefined),
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const onNeutral = useCallback(() => {
+    slideOut(
+      ({ finished }) =>
+        finished && onAction && onAction(ACTION_NEUTRAL, selectedDate),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedDate]);
 
   return (
     <Animated.View
@@ -94,8 +109,16 @@ const MonthPicker = ({
       }}>
       <View style={styles.pickerContainer}>
         <RNMonthPickerView
-          {...{ locale, onChange, onDone, onCancel }}
-          {...restProps}
+          {...{
+            locale,
+            onChange,
+            onDone,
+            onCancel,
+            onNeutral,
+            okButton,
+            cancelButton,
+            neutralButton,
+          }}
           style={styles.picker}
           value={value.getTime()}
           minimumDate={minimumDate.getTime()}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,4 @@
 export const ACTION_DATE_SET = 'dateSetAction';
 export const ACTION_DISMISSED = 'dismissedAction';
+export const ACTION_NEUTRAL = 'neutralAction';
 export const NATIVE_FORMAT = 'M-YYYY';


### PR DESCRIPTION
New third button added requested in #46. This new button will return the selected date with a `NEUTRAL_ACTION` event. Check README `onChange` example for more details.