### PR TITLE
Update build.gradle to support React 0.69.0 & Gradle 7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -109,7 +109,8 @@ afterEvaluate { project ->
     task androidJavadoc(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += files(android.bootClasspath)
-        classpath += files(project.getConfigurations().getByName('compile').asList())
+        project.getConfigurations().getByName('implementation').setCanBeResolved(true)
+        classpath += files(project.getConfigurations().getByName('implementation').asList())
         include '**/*.java'
     }
 


### PR DESCRIPTION
compile has been removed. replacing with implementation.